### PR TITLE
Assignment not showing in Grade me block

### DIFF
--- a/plugins/assign/assign_plugin.php
+++ b/plugins/assign/assign_plugin.php
@@ -55,7 +55,7 @@ function block_grade_me_query_assign($gradebookusers) {
    LEFT JOIN {assign_grades} ag ON ag.assignment = asgn_sub.assignment AND ag.userid = asgn_sub.userid AND
         asgn_sub.attemptnumber = ag.attemptnumber
        WHERE asgn_sub.userid $insql AND asgn_sub.status = 'submitted' AND a.grade <> 0
-         AND (ag.grade = -1 OR asgn_sub.timemodified >= ag.timemodified)";
+         AND (ag.id IS NULL OR asgn_sub.timemodified >= ag.timemodified)";
 
     return array($query, $inparams);
 }

--- a/tests/grade_me_test.php
+++ b/tests/grade_me_test.php
@@ -485,8 +485,15 @@ class block_grade_me_testcase extends advanced_testcase {
         $rec3->submissionid = '7';
         $rec3->userid = $users[0]->id;
         $rec3->timesubmitted = '6';
+        
+        $rec4 = new stdClass();
+        $rec4->id = $plugins[1]->id;
+        $rec4->courseid = $courses[0]->id;
+        $rec4->submissionid = '1';
+        $rec4->userid = $users[0]->id;
+        $rec4->timesubmitted = '1';
 
-        $expected = array($rec->id => $rec, $rec2->id => $rec2, $rec3->id => $rec3);
+        $expected = array($rec->id => $rec, $rec2->id => $rec2, $rec3->id => $rec3, $rec4->id => $rec4);
         $actual = $DB->get_records_sql($sql, $insqlparams);
         $this->assertEquals($expected, $actual);
         $this->assertFalse(block_grade_me_query_assign(array()));


### PR DESCRIPTION
Fixes 
1. Unit test failed because the condition asgn_sub.timemodified >= ag.timemodified were not met, so i have added one additional dataset in test_query_assign function to ensure the assertEquals pass. 

2. Replaced **the ag.grade = -1** by older condition **ag.id IS NULL**, as the system creates assign_grades entry in some scenarios with grade -1 and datemodifed, so in that case we don't probably need two condition on same OR statements, so checking ag.id is null would be perfect.

