### PR TITLE
Fix issues where learners to be graded quizzes dont appear

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -83,8 +83,8 @@ function block_grade_me_enabled_plugins() {
  * @return array $gradeables
  */
 function block_grade_me_array($gradeables, $r) {
-    // Make a unique key
-    $uniquekey = "{$r->courseid}_{$r->itemmodule}_{$r->iteminstance}_{$r->itemsortorder}_{$r->userid}_{$r->timefinish}";
+    // Make a unique key.
+    $uniquekey = "{$r->courseid}_{$r->itemmodule}_{$r->iteminstance}_{$r->itemsortorder}_{$r->userid}_{$r->timesubmitted}";
 
     $gradeables['meta']['courseid'] = $r->courseid;
     $gradeables['meta']['coursename'] = $r->coursename;
@@ -94,7 +94,7 @@ function block_grade_me_array($gradeables, $r) {
     $gradeables[$r->itemsortorder]['meta']['coursemoduleid'] = $r->coursemoduleid;
     $gradeables[$r->itemsortorder][$uniquekey]['meta']['userid'] = $r->userid;
     $gradeables[$r->itemsortorder][$uniquekey]['meta']['submissionid'] = $r->submissionid;
-    $gradeables[$r->itemsortorder][$uniquekey]['meta']['timefinish'] = $r->timefinish;
+    $gradeables[$r->itemsortorder][$uniquekey]['meta']['timesubmitted'] = $r->timesubmitted;
     if (isset($r->forum_discussion_id)) {
         $gradeables[$r->itemsortorder][$uniquekey]['meta']['forum_discussion_id'] = $r->forum_discussion_id;
     }
@@ -172,7 +172,7 @@ function block_grade_me_tree($course) {
         $useridlist = array();
 
         foreach ($item as $submission) {
-            $timesubmitted = $submission['meta']['timefinish'];
+            $timesubmitted = $submission['meta']['timesubmitted'];
             $userid = $submission['meta']['userid'];
             $submissionid = $submission['meta']['submissionid'];
 

--- a/lib.php
+++ b/lib.php
@@ -83,16 +83,20 @@ function block_grade_me_enabled_plugins() {
  * @return array $gradeables
  */
 function block_grade_me_array($gradeables, $r) {
+    // Make a unique key
+    $uniquekey = "{$r->courseid}_{$r->itemmodule}_{$r->iteminstance}_{$r->itemsortorder}_{$r->userid}_{$r->timefinish}";
+
     $gradeables['meta']['courseid'] = $r->courseid;
     $gradeables['meta']['coursename'] = $r->coursename;
     $gradeables[$r->itemsortorder]['meta']['iteminstance'] = $r->iteminstance;
     $gradeables[$r->itemsortorder]['meta']['itemmodule'] = $r->itemmodule;
     $gradeables[$r->itemsortorder]['meta']['itemname'] = $r->itemname;
     $gradeables[$r->itemsortorder]['meta']['coursemoduleid'] = $r->coursemoduleid;
-    $gradeables[$r->itemsortorder][$r->timesubmitted]['meta']['userid'] = $r->userid;
-    $gradeables[$r->itemsortorder][$r->timesubmitted]['meta']['submissionid'] = $r->submissionid;
+    $gradeables[$r->itemsortorder][$uniquekey]['meta']['userid'] = $r->userid;
+    $gradeables[$r->itemsortorder][$uniquekey]['meta']['submissionid'] = $r->submissionid;
+    $gradeables[$r->itemsortorder][$uniquekey]['meta']['timefinish'] = $r->timefinish;
     if (isset($r->forum_discussion_id)) {
-        $gradeables[$r->itemsortorder][$r->timesubmitted]['meta']['forum_discussion_id'] = $r->forum_discussion_id;
+        $gradeables[$r->itemsortorder][$uniquekey]['meta']['forum_discussion_id'] = $r->forum_discussion_id;
     }
     return($gradeables);
 }
@@ -167,8 +171,8 @@ function block_grade_me_tree($course) {
         $useridlistid = $coursemoduleid.time();
         $useridlist = array();
 
-        foreach ($item as $l3 => $submission) {
-            $timesubmitted = $l3;
+        foreach ($item as $submission) {
+            $timesubmitted = $submission['meta']['timefinish'];
             $userid = $submission['meta']['userid'];
             $submissionid = $submission['meta']['submissionid'];
 

--- a/plugins/quiz/quiz_plugin.php
+++ b/plugins/quiz/quiz_plugin.php
@@ -41,7 +41,7 @@ function block_grade_me_query_quiz($gradebookusers) {
         return false;
     }
     list($insql, $inparams) = $DB->get_in_or_equal($gradebookusers);
-    $query = ", qas.id step_id, qza.userid, qza.timemodified timemodified, qza.timefinish timefinish, qza.id submissionid, qas.sequencenumber
+    $query = ", qas.id step_id, qza.userid, qza.timemodified timemodified, qza.timefinish timesubmitted, qza.id submissionid, qas.sequencenumber
         FROM {question_attempt_steps} qas
         JOIN {block_grade_me_quiz_ngrade} bneeds ON bneeds.questionattemptstepid = qas.id
                                                     AND bneeds.userid $insql

--- a/plugins/quiz/quiz_plugin.php
+++ b/plugins/quiz/quiz_plugin.php
@@ -41,7 +41,7 @@ function block_grade_me_query_quiz($gradebookusers) {
         return false;
     }
     list($insql, $inparams) = $DB->get_in_or_equal($gradebookusers);
-    $query = ", qas.id step_id, qza.userid, qza.timemodified timesubmitted, qza.id submissionid, qas.sequencenumber
+    $query = ", qas.id step_id, qza.userid, qza.timemodified timemodified, qza.timefinish timefinish, qza.id submissionid, qas.sequencenumber
         FROM {question_attempt_steps} qas
         JOIN {block_grade_me_quiz_ngrade} bneeds ON bneeds.questionattemptstepid = qas.id
                                                     AND bneeds.userid $insql


### PR DESCRIPTION
This happens when a bunch of learners are regraded. Gradeable items are keyed up on the timemodified for a learners quiz attempt. Regrading a bunch of learners gives them the same timemodified value so when gradeables are added to the array the latest version of the same timemodified quiz attempt overrides the previous version.

1. Update sql for quiz to use timemodified as timemodified and timefinished as timefinished
2. Generate a key that is unique for a learner, course and quiz attempt
3. Use the real time submitted when outputting