### PR TITLE
added new config setting, added language strings, changed lib.php to …

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ Developers will triage issues and deal with more serious problems first. We will
 
 ## What is different in this branch (Madhu Avasarala)
 - This branch is customized to add a config setting to include hidden courses. If selected, hidden courses will also be searched for ungraded items.
+- The db/tasks.php file has been edited to set the update time for 30m every hour and reset every day at 03:15

--- a/README.md
+++ b/README.md
@@ -24,3 +24,6 @@ To help developers debug problems, please include the following in all issues:
 - Any other environmental information available.
 
 Developers will triage issues and deal with more serious problems first. We will try to address all issues but cannot guarantee when your issue will be addressed.
+
+## What is different in this branch (Madhu Avasarala)
+- This branch is customized to add a config setting to include hidden courses. If selected, hidden courses will also be searched for ungraded items.

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -15,6 +15,8 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
+ * Every day 1t 03:15 server time, a reset is done
+ * Every hour of every day at 30m intervals, the cache is updated with grade activities due
  * @package    block_grade_me
  * @copyright  2017 Derek Henderson {@link http://www.remote-learner.net}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
@@ -25,7 +27,7 @@ $tasks = array(
     array(
         'classname' => 'block_grade_me\task\cache_grade_data',
         'blocking' => 0,
-        'minute' => '*/15',
+        'minute' => '*/30',
         'hour' => '*',
         'day' => '*',
         'dayofweek' => '*',
@@ -35,7 +37,7 @@ $tasks = array(
         'classname' => 'block_grade_me\task\reset_block',
         'blocking' => 0,
         'minute' => '15',
-        'hour' => '1',
+        'hour' => '3',
         'day' => '*',
         'dayofweek' => '*',
         'month' => '*'

--- a/lang/en/block_grade_me.php
+++ b/lang/en/block_grade_me.php
@@ -37,6 +37,8 @@ $string['settings_maxcourses'] = 'Maximum Courses Displayed';
 $string['settings_configmaxcourses'] = 'Set the maximum number of ungraded courses to show. Setting this too high may impact performance.';
 $string['settings_adminviewall'] = 'Admins View All';
 $string['settings_configadminviewall'] = 'Enable to give administrators the rights to see all ungraded work — not just for courses where they have a grader role.';
+$string['settings_hiddencourses'] = 'Hidden courses also to be searched for ungraded work';
+$string['settings_confighiddencourses'] = 'Include hidden courses also to be searched for ungraded work';
 $string['settings_enablepre'] = 'Show';
 $string['settings_configenablepre'] = 'Should Grade Me show unrated activity from the "{$a->plugin_name}" module?';
 

--- a/lib.php
+++ b/lib.php
@@ -248,18 +248,26 @@ function block_grade_me_cache_grade_data() {
                        or b.pagetypepattern = ?)";
     $systemblock = $DB->get_record_sql($sqlsystem, $paramsystem);
     $systemcount = $systemblock->bcount;
-    // Get the list of all active courses in the database.
+    // Get the list of all courses in the database depending on config vivible setting
+    if ($CFG->block_grade_me_includehiddencourses)
+    {
+        $show = '0';
+    }
+    else
+    {
+        $show = '1';
+    }
     $paramscourse = array();
     if ($systemcount > '0') {
         $sqlactive = "SELECT c.id, c.timemodified
                        FROM {course} c
-                      WHERE c.visible = '1'";
+                      WHERE (c.visible = '1' or c.visible = $show)";
     } else {
         $sqlactive = "SELECT c.id, c.timemodified
                        FROM {course} c
                        JOIN {context} x ON c.id = x.instanceid
                        JOIN {block_instances} b ON b.parentcontextid = x.id
-                      WHERE b.blockname = 'grade_me' and c.visible = '1'";
+                      WHERE b.blockname = 'grade_me' and (c.visible = '1' or c.visible = $show)";
     }
     $courselist = $DB->get_recordset_sql($sqlactive, $paramscourse);
     foreach ($courselist as $actcourse) {

--- a/settings.php
+++ b/settings.php
@@ -20,6 +20,10 @@ if ($ADMIN->fulltree) {
 
     $settings->add(new admin_setting_configcheckbox('block_grade_me_enableadminviewall',
         get_string('settings_adminviewall', 'block_grade_me'), get_string('settings_configadminviewall', 'block_grade_me'), 0));
+        
+    // new setting added to include hidden courses to also be searched for gradeable activities
+    $settings->add(new admin_setting_configcheckbox('block_grade_me_includehiddencourses',
+        get_string('settings_hiddencourses', 'block_grade_me'), get_string('settings_confighiddencourses', 'block_grade_me'), 0));
 
     $settings->add(new admin_setting_configtext('block_grade_me_maxcourses', get_string('settings_maxcourses', 'block_grade_me'),
         get_string('settings_configmaxcourses', 'block_grade_me'), 10, PARAM_INT));


### PR DESCRIPTION
…include hidden courses based on setting.
The MOODLE_38_STABLE branch only looks at courses that are set to be visible.
In our institution, to prevent children from being exposed to courses that they are not enrolled in, all courses are set to be hidden.
The existing version of the plugin therefore misses all of the relevant courses and shows nothing left to be graded even when ungraded items are present in these hidden courses.

In my fork I created a new admin setting that includes hidden courses, defaulting to 0 which falls back to performance of old.
When admin sets the setting by checking the box, then a small code change in the lib.php where courses are searched for now will include hidden courses also.