### PR TITLE
Simple Quiz feature

### DIFF
--- a/classes/quiz_observers.php
+++ b/classes/quiz_observers.php
@@ -92,6 +92,12 @@ class quiz_observers {
      * @return void
      */
     public static function attempt_submitted($event) {
+	$simplequiz = get_config('block_grade_me','simplequiz');
+	//if we are doing simple quiz checkign, skip this
+	if($simplequiz){
+	    return;
+	}
+
         \block_grade_me\quiz_util::update_quiz_ngrade($event->objectid);
     }
 
@@ -103,6 +109,13 @@ class quiz_observers {
      */
     public static function question_manually_graded(\mod_quiz\event\question_manually_graded $event) {
         global $DB;
+
+	//if we are doing simple quiz checkign, skip this
+	$simplequiz = get_config('block_grade_me','simplequiz');
+	if($simplequiz){
+	    return;
+	}
+
         // Lookup uniqueid from quiz_attempts table.
         $record = $DB->get_record('quiz_attempts', ['id' => $event->other['attemptid']]);
         if (empty($record)) {

--- a/lang/en/block_grade_me.php
+++ b/lang/en/block_grade_me.php
@@ -49,3 +49,6 @@ $string['grade_me_tools_desc'] = '<p><a href="{$a}/blocks/grade_me/quiz_update_n
 
 $string['quiz_update_ngrade_complete'] = 'Update complete';
 $string['quiz_update_ngrade_success'] = 'Quiz attempt list successfully updated, currently there is {$a} questions needing grading.';
+
+$string['simplequiz'] = 'Simpler Quiz Check';
+$string['simplequiz_desc'] = 'The standard method of checking quiz completion requires queries against the question attempts table. For courses with lots of users, this can be a very slow and memory intensive process. Normally the plugin checks to make sure every manually graded question attempt has been reviewed, enabling this setting makes the plugin just check to see if the whole quiz has been assigned a grade. If you disable this setting, you will need to run the \'Refresh quiz attempts needing grading\' tool';

--- a/lib.php
+++ b/lib.php
@@ -334,6 +334,13 @@ function block_grade_me_cache_grade_data() {
                     $DB->update_record('block_grade_me', $params);
                 }
             }
+
+
+	    //If using simple quiz grade checking, we don't need to cache data about manually graded questions
+	    $simplequiz = get_config('block_grade_me','simplequiz');
+	    if($simplquiz){
+                continue;
+	    }
             /**
              * Build the quiz table per course. Cannot do this in bulk
              * because temp tables can cause large disk usage.

--- a/settings.php
+++ b/settings.php
@@ -39,6 +39,11 @@ if ($ADMIN->fulltree) {
         }
     }
 
+
+    $settings->add(new admin_setting_configcheckbox('block_grade_me/simplequiz', get_string('simplequiz', 'block_grade_me'),
+        get_string('simplequiz_desc', 'block_grade_me'), 0));
+
+
     $label = get_string('grade_me_tools', 'block_grade_me');
     $desc = get_string('grade_me_tools_desc', 'block_grade_me', $CFG->wwwroot);
     $settings->add(new admin_setting_heading('grade_me_tools', $label, $desc));

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2019111800;
+$plugin->version = 2019111802;
 $plugin->requires = 2019111800;
 $plugin->cron = 3600;
 $plugin->component = 'block_grade_me';


### PR DESCRIPTION
We have a large moodle site with some courses haveing ~1.5k students. We've found that the queries against the mdl_question_attempts table are too slow. This request adds a setting that changes the query to instead see if the sumgrade has been set for the quiz attempt. This drastically speeds things up and reduces memory usage. 

I assume I'll need to do some revisions (and write some tests), but I wanted to get this on your radar ASAP. 

Thoughts?