### PR TITLE
Whole forum grading

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -148,7 +148,11 @@ function block_grade_me_tree($course) {
         $coursemoduleid = $item['meta']['coursemoduleid'];
         unset($item['meta']);
 
-        $modulelink = $CFG->wwwroot . '/mod/' . $itemmodule . '/view.php?id=' . $coursemoduleid;
+        if ($itemmodule == 'wholeforum') {
+            $modulelink = '/mod/forum/view.php?id=' . $coursemoduleid;
+        } else {
+            $modulelink = $CFG->wwwroot . '/mod/' . $itemmodule . '/view.php?id=' . $coursemoduleid;
+        }
         $gradelink = $CFG->wwwroot;
         if ($itemmodule == 'assignment') {
             $gradelink .= '/mod/assignment/submissions.php?id=' . $coursemoduleid;
@@ -158,7 +162,11 @@ function block_grade_me_tree($course) {
             $gradelink = $modulelink;
         }
         $moduletitle = get_string('link_mod', 'block_grade_me', array('mod_name' => $itemmodule));
-        $moduleicon = $OUTPUT->pix_icon('icon', $moduletitle, $itemmodule, array('class' => 'gm_icon'));
+        if ($itemmodule == 'wholeforum') {
+            $moduleicon = $OUTPUT->pix_icon('icon', $moduletitle, 'forum', array('class' => 'gm_icon'));
+        } else {
+            $moduleicon = $OUTPUT->pix_icon('icon', $moduletitle, $itemmodule, array('class' => 'gm_icon'));
+        }
 
         $text .= '<dd id="cmid' . $coursemoduleid . '" class="module">' . "\n";  // Open module.
         $text .= '<div class="dd-wrap">' . "\n";
@@ -200,6 +208,8 @@ function block_grade_me_tree($course) {
             } else if ($itemmodule == 'lesson') {
                 $submissionlink .= '/mod/lesson/essay.php?id=' . $coursemoduleid . '&mode=grade&attemptid='
                                    . $submissionid . '&sesskey=' . sesskey();
+            } else if ($itemmodule == 'wholeforum') {
+                $submissionlink = $gradelink;
             }
 
             unset($submission['meta']);
@@ -324,6 +334,7 @@ function block_grade_me_cache_grade_data() {
             $sql = "SELECT gi.id itemid, gi.itemname itemname, gi.itemtype itemtype,
                            gi.itemmodule itemmodule, gi.iteminstance iteminstance,
                            gi.sortorder itemsortorder, c.id courseid, c.shortname coursename,
+                           gi.itemnumber itemnumber,
                            cm.id coursemoduleid
                     FROM {grade_items} gi
                LEFT JOIN {course} c ON gi.courseid = c.id
@@ -336,6 +347,9 @@ function block_grade_me_cache_grade_data() {
             $paramscourse = array_merge($paramscourse, $inparams);
             $rs = $DB->get_recordset_sql($sql, $paramscourse);
             foreach ($rs as $rec) {
+                if ($rec->itemmodule == 'forum' && $rec->itemnumber == 1) { 
+                    $rec->itemmodule = 'wholeforum'; 
+                }
                 $values = array(
                     'itemtype'      => $rec->itemtype,
                     'itemmodule'    => $rec->itemmodule,

--- a/plugins/wholeforum/wholeforum_plugin.php
+++ b/plugins/wholeforum/wholeforum_plugin.php
@@ -1,0 +1,53 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+function block_grade_me_required_capability_wholeforum() {
+    $enabledplugins['wholeforum'] = array(
+        'capability' => 'mod/forum:grade',
+        'default_on' => false,
+        'versiondependencies' => 'ANY_VERSION'
+        );
+    return $enabledplugins;
+}
+
+/**
+ * Build SQL query for the forum plugin
+ *
+ * @param array $gradebookusers ID's of gradebook users
+ * @return array|bool SQL query and parameters or false on failure
+ */
+function block_grade_me_query_wholeforum($gradebookusers) {
+    global $USER, $DB;
+
+    if (empty($gradebookusers)) {
+        return false;
+    }
+    list($insql, $inparams) = $DB->get_in_or_equal($gradebookusers);
+
+    $query = ", fp.id submissionid, fp.userid, fp.modified timesubmitted
+        FROM {forum_posts} fp
+        JOIN {forum_discussions} fd ON fd.id = fp.discussion
+        JOIN {forum} f ON f.id = fd.forum
+        JOIN {grade_items} gi ON gi.iteminstance = f.id
+             AND gi.itemmodule = 'forum' AND gi.itemnumber = 1
+   LEFT JOIN {grade_grades} gg ON gg.itemid = gi.id AND gg.userid = fp.userid
+   LEFT JOIN {block_grade_me} bgm ON bgm.courseid = f.course AND bgm.iteminstance = f.id
+       WHERE fp.userid $insql
+         AND f.grade_forum != 0
+         AND gg.finalgrade IS NULL ";
+
+    return array($query, $inparams);
+}

--- a/settings.php
+++ b/settings.php
@@ -46,6 +46,13 @@ if ($ADMIN->fulltree) {
                     $settingname = 'block_grade_me_enable' . $plugin;
                     $default = (isset($a[$plugin]) && isset($a[$plugin]['default_on'])) ? $a[$plugin]['default_on'] : false;
                     $settings->add(new admin_setting_configcheckbox($settingname, $langshowmod, $langshowdesc, $default));
+                } else if ($plugin == 'wholeforum' && \core_plugin_manager::instance()->get_plugin_info('forum')) {
+                    $langmodname = get_string('grade_forum_name', 'forum');
+                    $langshowmod = get_string('settings_enablepre', 'block_grade_me') . ' ' . $langmodname;
+                    $langshowdesc = get_string('settings_configenablepre', 'block_grade_me', ['plugin_name' => $langmodname]);
+                    $settingname = 'block_grade_me_enable' . $plugin;
+                    $default = (isset($a[$plugin]) && isset($a[$plugin]['default_on'])) ? $a[$plugin]['default_on'] : false;
+                    $settings->add(new admin_setting_configcheckbox($settingname, $langshowmod, $langshowdesc, $default));
                 }
             }
         }

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2021051702;
+$plugin->version = 2022100402;
 $plugin->requires = 2021051700;
 $plugin->cron = 3600;
 $plugin->component = 'block_grade_me';


### PR DESCRIPTION
This resolves #48 

Whole forum grading is added as a separate plugin from forum, so the administrator can enable or disable them separately. Whole forum grading uses a separate permission capability from rating as well, so some teachers should not be able to see both options. Whole forum grading uses the same icon as forum ratings, but the grade items will have different names unless the administrator has changed the language strings related to the forum mod. The grading links lead directly to the module page, because as far as I can tell there is no way to hyperlink directly to the grading overlay let alone to a particular user.